### PR TITLE
fixing error 400 incorrect postal code

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Example:
         width: 54.234,
         height: 12
       },
-      destinationPostalCode: 'H0H0H0'
+      destinationPostalCode: 'K1A0A6'
     }, function(err, rates) {
       console.log(err,rates);
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -105,7 +105,7 @@ CanadaPost.prototype.getRates = function(params, callback) {
     parseXML(body, function(err, result) {
       if (err) return callback(err);
 
-      if (response.statusCode === 403) {
+      if (response.statusCode !== 200) {
         return callback(new Error(result.messages.message[0].description[0]));
       }
 


### PR DESCRIPTION
Readme example provides santa's address but it's no longer valid and throws a 400 error. Fixed the condition so that the callback will display 400 errors. Changed readme address to parliament hill.